### PR TITLE
Use $ACTSTRACKING_DATA for acts data instead of /code

### DIFF
--- a/k4Reco/steer_reco.py
+++ b/k4Reco/steer_reco.py
@@ -316,7 +316,7 @@ CKFTracking.Parameters = {
     "CKF_NumMeasurementsCutOff": ["1"],
     "CaloFace_Radius": ["1857"],
     "CaloFace_Z": ["2307"],
-    "MatFile": [f"{the_args.code}/detector-simulation/geometries/MAIA_v0/MAIA_v0_material.json"],
+    "MatFile": [os.environ['ACTSTRACKING_DATA']+"/MAIA_v0_material.json"],
     "PropagateBackward": ["False"],
     "DetectorSchema": ["MAIA_v0"],
     "RunCKF": ["True"],
@@ -347,7 +347,7 @@ CKFTracking.Parameters = {
                       "8", "2",
                       "17", "2",
                       "18", "2"],
-    "TGeoFile": [f"{the_args.code}/detector-simulation/geometries/MAIA_v0/MAIA_v0.root"],
+    "TGeoFile": [os.environ['ACTSTRACKING_DATA']+"/MAIA_v0.root"],
     "TGeoDescFile": [os.environ['ACTSTRACKING_DATA']+"/MAIA_v0.json"],
     "TrackCollectionName": ["AllTracks"],
     "TrackerHitCollectionNames": ["VBTrackerHitsConed", "IBTrackerHitsConed", "OBTrackerHitsConed", "VETrackerHitsConed", "IETrackerHitsConed", "OETrackerHitsConed"]


### PR DESCRIPTION
Hi @madbaron , I noticed `MAIA_v0_material.json` and `MAIA_v0.root` don't live inside `detector-simulation` anymore. How do you feel about using `os.environ['ACTSTRACKING_DATA']` to steer these paths, since it's already used for TGeoDescFile (`MAIA_v0.json`)?

I think `/code/ACTSTracking` (`{the_args.code}/ACTSTracking`) is also a good option if we think geometry development happens faster than containers are updated
