### PR TITLE
Make output compression level set-able

### DIFF
--- a/k4Reco/steer_reco.py
+++ b/k4Reco/steer_reco.py
@@ -106,7 +106,7 @@ else:
         "LCIOOutputFile": [f"{the_args.data}/recoBIB/{the_args.TypeEvent}/{the_args.TypeEvent}_reco_{the_args.InFileName}.slcio"],
         "LCIOWriteMode": ["WRITE_NEW"]
     }
-if the_args.compressionLevel:
+if the_args.compressionLevel is not None:
     Output_REC.Parameters["CompressionLevel"] = [str(the_args.compressionLevel)]
 
 InitDD4hep = MarlinProcessorWrapper("InitDD4hep")

--- a/k4Reco/steer_reco.py
+++ b/k4Reco/steer_reco.py
@@ -14,6 +14,7 @@ parser.add_argument("--TypeEvent", type=str, default="electronGun_pT_0_50", help
 parser.add_argument("--InFileName", type=str, default="0", help="Input file name for the simulation")
 parser.add_argument("--code", type=str, default="/code", help="Top-level directory for code")
 parser.add_argument("--data", type=str, default="/dataMuC", help="Top-level directory for data")
+parser.add_argument("--compressionLevel", type=int, default=None, help="Set compression level of output")
 parser.add_argument("--skipReco", action="store_true", default=False, help="Skip reconstruction")
 parser.add_argument("--skipTrackerConing", action="store_true", default=False, help="Skip tracker coning")
 the_args = parser.parse_args()
@@ -105,6 +106,8 @@ else:
         "LCIOOutputFile": [f"{the_args.data}/recoBIB/{the_args.TypeEvent}/{the_args.TypeEvent}_reco_{the_args.InFileName}.slcio"],
         "LCIOWriteMode": ["WRITE_NEW"]
     }
+if the_args.compressionLevel:
+    Output_REC.Parameters["CompressionLevel"] = [str(the_args.compressionLevel)]
 
 InitDD4hep = MarlinProcessorWrapper("InitDD4hep")
 InitDD4hep.OutputLevel = INFO


### PR DESCRIPTION
Hi @madbaron ! Here is a PR which adds a command-line option to set the compression level of the output.

Relevant documentation:
- https://github.com/iLCSoft/Marlin/pull/39/files
- https://github.com/iLCSoft/Marlin/blob/master/source/src/LCIOOutputProcessor.cc
- https://github.com/iLCSoft/Marlin/blob/master/source/include/marlin/LCIOOutputProcessor.h

I faced an error while processing lots of BIB (100% bib, un-coned, loosened timing cuts):

```
EventLoopMgr        FATAL .executeEvent(): Standard std::exception thrown by Output_REC
EventLoopMgr        ERROR src/compression/zlib.cc (l.67) in compress: Zlib compression failed with status -5 [compress_error]
```

It was natural to work around this error by disabling zlib compression (CompressionLevel=0)