### PR TITLE
Portability changes: make running out of the box easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+PandoraSettings/temp_PandoraSettingsDefault.xml

--- a/k4Reco/steer_reco.py
+++ b/k4Reco/steer_reco.py
@@ -4,6 +4,7 @@ from Gaudi.Configuration import *
 from Configurables import LcioEvent, EventDataSvc, MarlinProcessorWrapper
 from k4MarlinWrapper.parseConstants import *
 
+import glob
 import os
 
 from k4FWCore.parseArgs import parser
@@ -17,6 +18,9 @@ parser.add_argument("--data", type=str, default="/dataMuC", help="Top-level dire
 parser.add_argument("--compressionLevel", type=int, default=None, help="Set compression level of output")
 parser.add_argument("--skipReco", action="store_true", default=False, help="Skip reconstruction")
 parser.add_argument("--skipTrackerConing", action="store_true", default=False, help="Skip tracker coning")
+parser.add_argument("--inputFile", type=str, default="", help="Input file, if set ignores the automatic path lookup in `--data`")
+parser.add_argument("--outputFile", type=str, default="", help="Output file, if set ignores the automatic output path generation in `--data`")
+parser.add_argument("--useLocalThresholds", action="store_true", default=False, help="Read MyBIBUtils thresholds files from code directory, rather than from the container")
 the_args = parser.parse_args()
 
 Coned = "" if the_args.skipTrackerConing else "Coned"
@@ -31,7 +35,10 @@ parseConstants(CONSTANTS)
 
 read = LcioEvent()
 read.OutputLevel = INFO
-read.Files = [f"{the_args.data}/sim/{the_args.TypeEvent}/{the_args.TypeEvent}_sim_{the_args.InFileName}.slcio"]
+if the_args.inputFile == "":
+    read.Files = [f"{the_args.data}/sim/{the_args.TypeEvent}/{the_args.TypeEvent}_sim_{the_args.InFileName}.slcio"]
+else:
+    read.Files = [the_args.inputFile]
 algList.append(read)
 
 EventNumber = MarlinProcessorWrapper("EventNumber")
@@ -58,7 +65,7 @@ if not the_args.enableBIB:
         "DropCollectionNames": [],
         "FullSubsetCollections": [],
         "KeepCollectionNames": ["MCParticle_SiTracks", "MCParticle_SelectedTracks"],
-        "LCIOOutputFile": [f"{the_args.data}/reco/{the_args.TypeEvent}/{the_args.TypeEvent}_reco_{the_args.InFileName}.slcio"],
+        "LCIOOutputFile": [the_args.outputFile if the_args.outputFile != "" else f"{the_args.data}/reco/{the_args.TypeEvent}/{the_args.TypeEvent}_reco_{the_args.InFileName}.slcio"],
         "LCIOWriteMode": ["WRITE_NEW"]
     }
 else:
@@ -103,9 +110,10 @@ else:
             "SiTracks", "SelectedTracks",
             "MCParticle_SiTracks", "MCParticle_SelectedTracks"
         ],
-        "LCIOOutputFile": [f"{the_args.data}/recoBIB/{the_args.TypeEvent}/{the_args.TypeEvent}_reco_{the_args.InFileName}.slcio"],
+        "LCIOOutputFile": [the_args.outputFile if the_args.outputFile != "" else f"{the_args.data}/recoBIB/{the_args.TypeEvent}/{the_args.TypeEvent}_reco_{the_args.InFileName}.slcio"],
         "LCIOWriteMode": ["WRITE_NEW"]
     }
+
 if the_args.compressionLevel is not None:
     Output_REC.Parameters["CompressionLevel"] = [str(the_args.compressionLevel)]
 
@@ -641,6 +649,21 @@ MyHcalEndcapConer.Parameters = {
     "ConeWidth": ["0.6"]
 }
 
+def findCaloThresholds(filename, codedir, use_code=False):
+    """ Helper function. Attempts to find the threshold files in the spack directory
+        containing both DD4HEP and MUCOLL_STACK (based on those environment variables).
+        If this fails for whatever reason, OR if requested by the user, these files are loaded from
+        a checkout of the MyBIBUtils package in the code directory."""
+    if use_code:
+        return os.path.join(codedir, filename)
+    else:
+        spack_root = os.path.commonpath([os.getenv("DD4HEP", ""), os.getenv("MUCOLL_STACK", "")])
+        try:
+            my_bib_utils = glob.glob(os.path.join(spack_root, "mybibutils*"))[0]
+            return os.path.join(my_bib_utils, "share", filename)
+        except IndexError:
+            print("Could not find MyBIBUtils in spack installation, will try to read threshold files from --code.")
+            return os.path.join(codedir, filename)
 
 MyEcalBarrelSelector = MarlinProcessorWrapper("MyEcalBarrelSelector")
 MyEcalBarrelSelector.OutputLevel = INFO
@@ -650,7 +673,7 @@ MyEcalBarrelSelector.Parameters = {
     "CaloRelationCollectionName": ["EcalBarrelRelationsSimConed"],
     "GoodHitCollection": ["EcalBarrelCollectionSel"],
     "GoodRelationCollection": ["EcalBarrelRelationsSimSel"],
-    "ThresholdsFilePath": [f"{the_args.code}/MyBIBUtils/data/ECAL_Thresholds_10TeV.root"],
+    "ThresholdsFilePath": [findCaloThresholds("MyBIBUtils/data/ECAL_Thresholds_10TeV.root", the_args.code, the_args.useLocalThresholds)],
     "Nsigma": ["0"],
     "TimeWindowMin": ["-0.3"],
     "TimeWindowMax": ["0.3"],
@@ -665,7 +688,7 @@ MyEcalEndcapSelector.Parameters = {
     "CaloRelationCollectionName": ["EcalEndcapRelationsSimConed"],
     "GoodHitCollection": ["EcalEndcapCollectionSel"],
     "GoodRelationCollection": ["EcalEndcapRelationsSimSel"],
-    "ThresholdsFilePath": [f"{the_args.code}/MyBIBUtils/data/ECAL_Thresholds_10TeV.root"],
+    "ThresholdsFilePath": [findCaloThresholds("MyBIBUtils/data/ECAL_Thresholds_10TeV.root", the_args.code, the_args.useLocalThresholds)],
     "Nsigma": ["0"],
     "TimeWindowMin": ["-0.3"],
     "TimeWindowMax": ["0.3"],
@@ -681,7 +704,7 @@ MyHcalBarrelSelector.Parameters = {
     "CaloRelationCollectionName": ["HcalBarrelRelationsSimConed"],
     "GoodHitCollection": ["HcalBarrelCollectionSel"],
     "GoodRelationCollection": ["HcalBarrelRelationsSimSel"],
-    "ThresholdsFilePath": [f"{the_args.code}/MyBIBUtils/data/HCAL_Thresholds_10TeV.root"],
+    "ThresholdsFilePath": [findCaloThresholds("MyBIBUtils/data/HCAL_Thresholds_10TeV.root", the_args.code, the_args.useLocalThresholds)],
     "FlatThreshold": ["5e-05"],
     "Nsigma": ["0"],
     "TimeWindowMin": ["-0.3"],
@@ -697,7 +720,7 @@ MyHcalEndcapSelector.Parameters = {
     "CaloRelationCollectionName": ["HcalEndcapRelationsSimConed"],
     "GoodHitCollection": ["HcalEndcapCollectionSel"],
     "GoodRelationCollection": ["HcalEndcapRelationsSimSel"],
-    "ThresholdsFilePath": [f"{the_args.code}/MyBIBUtils/data/HCAL_Thresholds_10TeV.root"],
+    "ThresholdsFilePath": [findCaloThresholds("MyBIBUtils/data/HCAL_Thresholds_10TeV.root", the_args.code, the_args.useLocalThresholds)],
     "FlatThreshold": ["5e-05"],
     "Nsigma": ["0"],
     "TimeWindowMin": ["-0.3"],
@@ -705,6 +728,21 @@ MyHcalEndcapSelector.Parameters = {
     "DoBIBsubtraction": ["false"]
 }
 
+def updatePandoraPaths(pandoraSettings, codedir):
+    """ Helper function to update XML paths in a PandoraSettings XML file.
+        Pandora itself doesn't seem to be able to do anything like this, which means that
+        absolute paths need to be specified."""
+    newpath = os.path.join(os.path.dirname(pandoraSettings), "temp_" + os.path.basename(pandoraSettings))
+    with open(pandoraSettings) as settingsFile:
+        text = settingsFile.read()
+    newtext = text.replace("/code", codedir)
+    with open(newpath, 'w') as newSettings:
+        newSettings.write(newtext)
+
+    return newpath
+
+pandoraSettingsFile = updatePandoraPaths(f"{the_args.code}/SteeringMacros/PandoraSettings/PandoraSettingsDefault.xml", the_args.code)
+print("Running using temporary PandoraSettings XML: " + pandoraSettingsFile)
 
 DDMarlinPandora = MarlinProcessorWrapper("DDMarlinPandora")
 DDMarlinPandora.OutputLevel = INFO
@@ -776,7 +814,7 @@ DDMarlinPandora.Parameters = {
     "NEventsToSkip": ["0"],
     "NOuterSamplingLayers": ["3"],
     "PFOCollectionName": ["PandoraPFOs"],
-    "PandoraSettingsXmlFile": [f"{the_args.code}/SteeringMacros/PandoraSettings/PandoraSettingsDefault.xml"],
+    "PandoraSettingsXmlFile": [pandoraSettingsFile],
     "ProngVertexCollections": ["ProngVertices"],
     "ReachesECalBarrelTrackerOuterDistance": ["-100"],
     "ReachesECalBarrelTrackerZMaxDistance": ["-50"],


### PR DESCRIPTION
Hi @madbaron,

I was looking into updating the MAIA instructions on the wiki to use the 2.11 container image (for now, as a stepping stone to porting things to the full-Gaudi setup). As part of that I was wondering if we could make it possible to run the digi+reco steering macro out of the box,without needing to clone any other repositories or edit anything by hand. And it looks like it is possible, though it required three modifications to your code.

* First; I added optional `--inputFile` and `--outputFile` arguments. If you don't set them everything behaves exactly as it did before (the files get found from the `--data` directory as specified), so it doesn't break anything, but it allows the user to override the automatic path lookup if they want, which I at least found useful for quick testing.

* Then, I noticed that in version 2.11 of the container we now ship with MyBIBUtils, which includes the ECal/HCal threshold files. The steering macro was still reading the files out of the code directory though (meaning the user needs to clone MyBIBUtils). There doesn't seem to be an environment variable pointing directly at the MyBIBUtils install directory, but we can (hackishly) find it by looking at the common path for some other environment variables coming from the mucoll-spack software stack. If this fails for whatever reason we fall back to trying to read the files from the code directory. This can also be explicitly requested by the user by setting a new flag, `--useLocalThresholds`, which seemed useful for testing different thresholds and also to preserve the current behavior. (We could change it so that this is the default and the automatic lookup requires a flag instead, if you prefer).

* Then we currently need to edit PandoraSettings.xml, since that file references another XML file which needs to be specified via an absolute path. I just wrote a function which opens PandoraSettings.xml, makes a copy in the same location, edits the path automatically (replacing /code with the_value of `--code`), and passes the copy to the processor. This seems to work; though again, we could make it optional or conditioned on via a flag if you don't want it to always happen.

I thought I'd open a merge request for these to see what you thought about them-- I could understand not wanting to e.g. always try and edit PandoraSettings.xml, that certainly feels like it could be a bit fragile to me. (I only did it this way because I looked into Pandora a bit and it seems like there's no way to remove the need for an absolute path without modifying Pandora itself...).