### PR TITLE
Force hits to surface in tracker digitization

### DIFF
--- a/k4Reco/steer_reco.py
+++ b/k4Reco/steer_reco.py
@@ -141,7 +141,8 @@ VXDBarrelDigitiser.Parameters = {
     "TimeWindowMax": ["0.15"],
     "TimeWindowMin": ["-0.09"],
     "TrackerHitCollectionName": ["VBTrackerHits"],
-    "UseTimeWindow": ["true"]
+    "UseTimeWindow": ["true"],
+    "ForceHitsOntoSurface": ["true"]
 }
 
 VXDEndcapDigitiser = MarlinProcessorWrapper("VXDEndcapDigitiser")
@@ -159,7 +160,8 @@ VXDEndcapDigitiser.Parameters = {
     "TimeWindowMax": ["0.15"],
     "TimeWindowMin": ["-0.09"],
     "TrackerHitCollectionName": ["VETrackerHits"],
-    "UseTimeWindow": ["true"]
+    "UseTimeWindow": ["true"],
+    "ForceHitsOntoSurface": ["true"]
 }
 
 InnerPlanarDigiProcessor = MarlinProcessorWrapper("InnerPlanarDigiProcessor")
@@ -177,7 +179,8 @@ InnerPlanarDigiProcessor.Parameters = {
     "TimeWindowMax": ["0.3"],
     "TimeWindowMin": ["-0.18"],
     "TrackerHitCollectionName": ["IBTrackerHits"],
-    "UseTimeWindow": ["true"]
+    "UseTimeWindow": ["true"],
+    "ForceHitsOntoSurface": ["true"]
 }
 
 InnerEndcapPlanarDigiProcessor = MarlinProcessorWrapper(
@@ -196,7 +199,8 @@ InnerEndcapPlanarDigiProcessor.Parameters = {
     "TimeWindowMax": ["0.3"],
     "TimeWindowMin": ["-0.18"],
     "TrackerHitCollectionName": ["IETrackerHits"],
-    "UseTimeWindow": ["true"]
+    "UseTimeWindow": ["true"],
+    "ForceHitsOntoSurface": ["true"]
 }
 
 OuterPlanarDigiProcessor = MarlinProcessorWrapper("OuterPlanarDigiProcessor")
@@ -214,7 +218,8 @@ OuterPlanarDigiProcessor.Parameters = {
     "TimeWindowMax": ["0.3"],
     "TimeWindowMin": ["-0.18"],
     "TrackerHitCollectionName": ["OBTrackerHits"],
-    "UseTimeWindow": ["true"]
+    "UseTimeWindow": ["true"],
+    "ForceHitsOntoSurface": ["true"]
 }
 
 OuterEndcapPlanarDigiProcessor = MarlinProcessorWrapper(
@@ -233,7 +238,8 @@ OuterEndcapPlanarDigiProcessor.Parameters = {
     "TimeWindowMax": ["0.3"],
     "TimeWindowMin": ["-0.18"],
     "TrackerHitCollectionName": ["OETrackerHits"],
-    "UseTimeWindow": ["true"]
+    "UseTimeWindow": ["true"],
+    "ForceHitsOntoSurface": ["true"]
 }
 
 VXDBarrelConer = MarlinProcessorWrapper("VXDBarrelConer")


### PR DESCRIPTION
This addresses an issue with the simple planar digitizer where hits that are not exactly on the center of the surface appear to get rejected, as they are flagged as being outside the detector geometry, even if they are inside the active volume of the silicon sensor. This seems to happen (more) frequently when BIB particles pass through a sensor at a very shallow impact angle; GEANT assigns the hit position to be further away from the center of the sensor, which the digitizer doesn't like.

@alexandertuna [showed](https://indico.desy.de/event/53317/contributions/203871/attachments/103148/143988/Tuna-2026-04-02-trackersimhits.pdf) that up to 40-50% of hits in the barrel detectors are getting discarded due to this effect, and we discussed in the MAIA meeting this morning that we probably want to use this option for future sample production to deal with this issue.